### PR TITLE
PLAY_SERVICES_VERSION preference

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -23,7 +23,10 @@
 
 	<!-- android -->
 	<platform name="android">
-		<framework src="com.google.android.gms:play-services-auth-api-phone:15.0.1"/>
+		
+		<preference name="PLAY_SERVICES_VERSION" default="11.8.0"/>
+		
+		<framework src="com.google.android.gms:play-services-auth-api-phone:$PLAY_SERVICES_VERSION"/>
 
 		<config-file target="res/xml/config.xml" parent="/*">
 			<feature name="SMSRetriever">


### PR DESCRIPTION
The PLAY_SERVICES_VERSION preference alow change the version of play store services.
This is important because other plugins may use other versions of play store services and this causes conflicts beetwen plugins and some maybe stop work. This realy happened with me when i used the google-plus plugin.