### PR TITLE
fix: Fatal Exception: java.lang.RuntimeException

### DIFF
--- a/src/android/SMSBroadcastReceiver.java
+++ b/src/android/SMSBroadcastReceiver.java
@@ -24,6 +24,9 @@ public class SMSBroadcastReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         if (SmsRetriever.SMS_RETRIEVED_ACTION.equals(intent.getAction())) {
             Bundle extras = intent.getExtras();
+            if (extras == null) {
+                return;
+            }
             Status status = (Status) extras.get(SmsRetriever.EXTRA_STATUS);
             if (status == null) {
                 return;


### PR DESCRIPTION

Nexus 5X
Android 8.1.0

`
          Fatal Exception: java.lang.RuntimeException: Unable to start receiver com.andreszs.smsretriever.SMSBroadcastReceiver: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object android.os.Bundle.get(java.lang.String)' on a null object reference
       at android.app.ActivityThread.handleReceiver(ActivityThread.java:3194)
       at android.app.ActivityThread.-wrap17()
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1672)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:164)
       at android.app.ActivityThread.main(ActivityThread.java:6494)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)

`