### PR TITLE
fix: java.lang.NullPointerException onActivityResult

### DIFF
--- a/src/android/SMSRetriever.java
+++ b/src/android/SMSRetriever.java
@@ -253,8 +253,12 @@ public class SMSRetriever extends CordovaPlugin implements SMSBroadcastReceiver.
 
             }
         } catch (ApiException | NullPointerException ex) {
-            getPhoneNumberCallbackContext.error(ex.getMessage());
-            ex.printStackTrace();
+            if(ex instanceof ApiException){
+                getPhoneNumberCallbackContext.error(ex.getMessage());
+            }
+            if(ex != null){
+                ex.printStackTrace();
+            }
         }
     }
 


### PR DESCRIPTION
```
      Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void 
      org.apache.cordova.CallbackContext.error(java.lang.String)' on a null object reference
       at com.andreszs.smsretriever.SMSRetriever.onActivityResult(SMSRetriever.java:256)
       at org.apache.cordova.CordovaInterfaceImpl.onActivityResult(CordovaInterfaceImpl.java:160)
       at org.apache.cordova.CordovaActivity.onActivityResult(CordovaActivity.java:375)
       at android.app.Activity.dispatchActivityResult(Activity.java:9362)
       at android.app.ActivityThread.deliverResults(ActivityThread.java:6056)
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:5396)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:5508)
       at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:57)
       at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:180)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:98)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2685)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:230)
       at android.os.Looper.loop(Looper.java:319)
       at android.app.ActivityThread.main(ActivityThread.java:8919)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:578)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
        

```